### PR TITLE
Switch to alpine for image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,15 @@
-FROM debian:jessie
-MAINTAINER Ilya Stepanov <dev@ilyastepanov.com>
+FROM python:3.7-alpine3.8
 
-RUN apt-get update && \
-    apt-get install -y python python-pip cron && \
-    rm -rf /var/lib/apt/lists/*
+LABEL version="0.2"
+LABEL maintainer="Ilya Stepanov <dev@ilyastepanov.com>"
 
-RUN pip install s3cmd
+COPY s3cfg start.sh sync.sh get.sh /
 
-ADD s3cfg /root/.s3cfg
-
-ADD start.sh /start.sh
-RUN chmod +x /start.sh
-
-ADD sync.sh /sync.sh
-RUN chmod +x /sync.sh
-
-ADD get.sh /get.sh
-RUN chmod +x /get.sh
+RUN pip install s3cmd \
+  && mv /s3cfg /root/.s3cfg \
+  && chmod +x /start.sh \
+  && chmod +x /sync.sh \
+  && chmod +x /get.sh
 
 ENTRYPOINT ["/start.sh"]
 CMD [""]

--- a/get.sh
+++ b/get.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 
@@ -18,15 +18,10 @@ elif [[ "$1" == 'get' ]]; then
 elif [[ "$1" == 'delete' ]]; then
     exec /usr/local/bin/s3cmd del -r "$S3_PATH"
 else
-    LOGFIFO='/var/log/cron.fifo'
-    if [[ ! -e "$LOGFIFO" ]]; then
-        mkfifo "$LOGFIFO"
-    fi
     CRON_ENV="PARAMS='$PARAMS'"
     CRON_ENV="$CRON_ENV\nDATA_PATH='$DATA_PATH'"
     CRON_ENV="$CRON_ENV\nS3_PATH='$S3_PATH'"
-    echo -e "$CRON_ENV\n$CRON_SCHEDULE /sync.sh > $LOGFIFO 2>&1" | crontab -
+    echo -e "$CRON_ENV\n$CRON_SCHEDULE /sync.sh" | crontab -
     crontab -l
-    cron
-    tail -f "$LOGFIFO"
+    crond -f
 fi

--- a/sync.sh
+++ b/sync.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 


### PR DESCRIPTION
Hi,

Hopefully this isn't too much like #9, but this switches the image base to Alpine rather than debian to shrink it down.  The motivator was that I'm looking to run this as a cron'd sidecar in a Kubernetes deployment, and switching the base along with a couple of bits of layer cleanup drops the image size from 354MB to ~86MB, which is probably a bigger savings than just the layer cleanup bits in #9. 

Running it on Alpine required updating the script parser from bash to ash, but everything seems to run fine with that setup.  I dropped the FIFO bit as logging to STDOUT seems to be the canonical way to do things in Docker and k8s land.

Feedback welcome :)